### PR TITLE
Updated serial port reference to support pi4

### DIFF
--- a/gui/gui.pde
+++ b/gui/gui.pde
@@ -233,7 +233,12 @@ public void setup()
     delay(2000);
     if(System.getProperty("os.arch").contains("arm"))
     {
-      startSerial("/dev/serial0",115200);
+      globalPortName = "/dev/serial0";
+      File f = new File(globalPortName);
+      if (!f.exists()) {
+        globalPortName = "/dev/ttyAMA0";
+      }
+      startSerial(globalPortName,115200);
       checkForExternalStorage();
     }
     
@@ -533,7 +538,7 @@ public void RecordData()
               bufferedWriter.newLine();
               bufferedWriter.write("Format: ECG, PPG, Respiration, Temperature, Heartrate, SpO2, Respiration Rate");
               bufferedWriter.newLine();
-              startSerial("/dev/serial0",115200);
+              startSerial(globalPortName,115200);
             }
             catch(Exception e)
             {

--- a/gui/gui.pde
+++ b/gui/gui.pde
@@ -233,7 +233,7 @@ public void setup()
     delay(2000);
     if(System.getProperty("os.arch").contains("arm"))
     {
-      startSerial("/dev/ttyAMA0",115200);
+      startSerial("/dev/serial0",115200);
       checkForExternalStorage();
     }
     
@@ -533,7 +533,7 @@ public void RecordData()
               bufferedWriter.newLine();
               bufferedWriter.write("Format: ECG, PPG, Respiration, Temperature, Heartrate, SpO2, Respiration Rate");
               bufferedWriter.newLine();
-              startSerial("/dev/ttyAMA0",115200);
+              startSerial("/dev/serial0",115200);
             }
             catch(Exception e)
             {


### PR DESCRIPTION
Changed default serial port from /dev/ttyAMA0 to /dev/serial0 for pi4 support. Currently UNTESTED on Pi3, will test shortly.